### PR TITLE
Reset border and padding of shadow div in the loader

### DIFF
--- a/Hyphenator_Loader.js
+++ b/Hyphenator_Loader.js
@@ -106,6 +106,7 @@ var Hyphenator_Loader = (function (window) {
                 if (languages.hasOwnProperty(lang)) {
                     shadow = createElem('div');
                     shadow.style.width = '5em';
+                    shadow.style.border = 'none';
                     shadow.lang = lang;
                     shadow.style['-webkit-locale'] = "'" + lang + "'";
                     shadow.appendChild(window.document.createTextNode(languages[lang]));

--- a/Hyphenator_Loader.js
+++ b/Hyphenator_Loader.js
@@ -107,6 +107,7 @@ var Hyphenator_Loader = (function (window) {
                     shadow = createElem('div');
                     shadow.style.width = '5em';
                     shadow.style.border = 'none';
+                    shadow.style.padding = '0';
                     shadow.lang = lang;
                     shadow.style['-webkit-locale'] = "'" + lang + "'";
                     shadow.appendChild(window.document.createTextNode(languages[lang]));


### PR DESCRIPTION
Finally found the cause of #231.
I had a set the following in my stylesheet:
```css
body > div > div {
      border: 6px …
}
```
As ``offsetHeight`` is calculated as ``height + padding + border`` it is probably a good idea to reset them. I wonder if other stylings would have to be reset?!

Fixes #231 
