### PR TITLE
Adding a config-param to setup when hyphenator starts

### DIFF
--- a/Hyphenator.js
+++ b/Hyphenator.js
@@ -878,6 +878,14 @@ Hyphenator = (function (window) {
     };
 
     /**
+     * @member {string} Hyphenate on this Window-Event
+     * @desc
+     * Hyphenate on this window-event, default 'complete'
+     * @access private
+     */
+    var hyphenationOnReadyState = 'complete';
+
+    /**
      * @name Hyphenator~selectorFunction
      * @desc
      * A function set by the user that has to return a HTMLNodeList or array of Elements to be hyphenated.
@@ -1401,7 +1409,7 @@ Hyphenator = (function (window) {
             }
         }
 
-        if (documentLoaded || w.document.readyState === 'complete') {
+        if (documentLoaded || w.document.readyState === hyphenationOnReadyState) {
             //Hyphenator has run already (documentLoaded is true) or
             //it has been loaded after onLoad
             documentLoaded = true;
@@ -3083,6 +3091,11 @@ Hyphenator = (function (window) {
             case 'onwarninghandler':
                 if (assert('onwarninghandler', 'function')) {
                     onWarning = obj[key];
+                }
+                break;
+            case 'hyphenationOnReadyState':
+                if(assert('hyphenationOnReadyState', 'string')) {
+                    hyphenationOnReadyState = obj[key];
                 }
                 break;
             case 'intermediatestate':


### PR DESCRIPTION
Originally Hyphenator waits for the "complete" state of document.readyState.

In an actual project I integrate Hyphenator as a dependency over require.js. I figured out, that Hyphenator uses the "complete"-state, because we load all images without width- and height-attributes in the prototype. So in that prototype Hyphenator waits for all images, to be loaded, before it initializes itself.

Because of that I integrated the support of configuring the readyState, for example to 'inteactive', what definitely is enough time to render text properly in a case, where all of the images have the width and height-attribute. In that case the page will not change anymore, except by async loaded javascript or javascript that will be executed after a timeout, but when I integrate javascript async I am aware of the problems and I will interoperate with Hyphenator.init.
