### PR TITLE
adds "main" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "author": "Mathias Nater",
   "license": "MIT",
+  "main": "Hyphenator.js",
   "bugs": {
     "url": "https://github.com/mnater/Hyphenator/issues"
   },


### PR DESCRIPTION
main

The main field is a module ID that is the primary entry point to your program. That is, if your package is named foo, and a user installs it, and then does require("foo"), then your main module's exports object will be returned.

This should be a module ID relative to the root of your package folder.

For most modules, it makes the most sense to have a main script and often not much else.

this commit fixes #305 