### PR TITLE
mnater/Hyphenator#275 returning default for IE 11

### DIFF
--- a/Hyphenator.js
+++ b/Hyphenator.js
@@ -151,6 +151,9 @@ Hyphenator = (function (window) {
         };
         var fullPath;
         function getBasePath(path) {
+            if (!path) {
+              return r.basePath;
+            }
             return path.substring(0, path.lastIndexOf("/") + 1);
         }
         function findCurrentScript() {


### PR DESCRIPTION
…when Hyphenator has been packaged in a vendor.js for instance.