### PR TITLE
mnater/Hyphenator#275 guarding fullPath (undefined in IE 11)

### DIFF
--- a/Hyphenator.js
+++ b/Hyphenator.js
@@ -177,7 +177,7 @@ Hyphenator = (function (window) {
             fullPath = findCurrentScript();
         }
         r.basePath = getBasePath(fullPath);
-        if (fullPath.indexOf("bm=true") !== -1) {
+        if (fullPath && fullPath.indexOf("bm=true") !== -1) {
             r.isBookmarklet = true;
         }
         if (window.location.href.indexOf(r.basePath) !== -1) {


### PR DESCRIPTION
Sorry, my previous fix was incomplete.